### PR TITLE
More TLS verification options

### DIFF
--- a/api/v1alpha1/issuer_types.go
+++ b/api/v1alpha1/issuer_types.go
@@ -42,6 +42,12 @@ type IssuerSpec struct {
 	// +optional
 	CaBundle *string `json:"caBundle,omitempty"`
 
+	// A boolean indicating if untrusted certificates should be allowed
+	// when connecting to the Horizon instance.
+	// +optional
+	// +kubebuilder:default:=false
+	SkipTLSVerify bool `json:"skipTLSVerify"`
+
 	// A boolean used to control whether this issuer should revoke certificates
 	// that have been issued through it when their Kubernetes object is deleted.
 	// +kubebuilder:default:=false

--- a/charts/horizon-issuer/crds/horizon.evertrust.io_clusterissuers.yaml
+++ b/charts/horizon-issuer/crds/horizon.evertrust.io_clusterissuers.yaml
@@ -70,9 +70,14 @@ spec:
                   revoke certificates that have been issued through it when their
                   Kubernetes object is deleted.
                 type: boolean
+              skipTLSVerify:
+                default: false
+                description: A boolean indicating if untrusted certificates should
+                  be allowed when connecting to the Horizon instance.
+                type: boolean
               url:
-                description: 'URL is the base URL for the endpoint of the signing
-                  service, for example: "https://sample-signer.example.com/api".'
+                description: 'URL is the base URL of your Horizon instance, for instance:
+                  "https://horizon.yourcompany.com".'
                 type: string
             required:
             - authSecretName

--- a/charts/horizon-issuer/crds/horizon.evertrust.io_issuers.yaml
+++ b/charts/horizon-issuer/crds/horizon.evertrust.io_issuers.yaml
@@ -69,9 +69,14 @@ spec:
                   revoke certificates that have been issued through it when their
                   Kubernetes object is deleted.
                 type: boolean
+              skipTLSVerify:
+                default: false
+                description: A boolean indicating if untrusted certificates should
+                  be allowed when connecting to the Horizon instance.
+                type: boolean
               url:
-                description: 'URL is the base URL for the endpoint of the signing
-                  service, for example: "https://sample-signer.example.com/api".'
+                description: 'URL is the base URL of your Horizon instance, for instance:
+                  "https://horizon.yourcompany.com".'
                 type: string
             required:
             - authSecretName

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/evertrust/horizon-issuer
 go 1.16
 
 require (
-	github.com/evertrust/horizon-go v0.0.0-20220405090940-041e01ad81b4
+	github.com/evertrust/horizon-go v0.0.2
 	github.com/jetstack/cert-manager v1.6.1
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWc
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evertrust/horizon-go v0.0.0-20220405090940-041e01ad81b4 h1:6zDAZahxrDBtx+n1Fn1y5vqXAjtKOgz2QtudMPq8S+M=
 github.com/evertrust/horizon-go v0.0.0-20220405090940-041e01ad81b4/go.mod h1:KmiC6YkLfhHPSpTjQ8/gt7i8jVrdmsURgOrqQKRoAD4=
+github.com/evertrust/horizon-go v0.0.2 h1:HYH8FfQpOyKTkJwb2rtGguTfcOJ/AfGZE6R4qsMeaOQ=
+github.com/evertrust/horizon-go v0.0.2/go.mod h1:KmiC6YkLfhHPSpTjQ8/gt7i8jVrdmsURgOrqQKRoAD4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/internal/issuer/horizon/issuer.go
+++ b/internal/issuer/horizon/issuer.go
@@ -30,6 +30,8 @@ func (r *HorizonIssuer) SubmitRequest(ctx context.Context, client client.Client,
 		profile,
 		certificateRequest.Spec.Request,
 		[]requests.LabelElement{},
+		nil,
+		nil,
 	)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("%w: %v", errors.New("unable to sign the CSR using Horizon"), err)

--- a/internal/issuer/horizon/util.go
+++ b/internal/issuer/horizon/util.go
@@ -22,5 +22,9 @@ func HorizonClientFromIssuer(issuerSpec *horizonapi.IssuerSpec, secretData map[s
 		client.Http.SetCaBundle(*issuerSpec.CaBundle)
 	}
 
+	if issuerSpec.SkipTLSVerify {
+		client.Http.SkipTLSVerify()
+	}
+
 	return client, nil
 }


### PR DESCRIPTION
- Specify a CA bundle to trust Horizon's TLS certificate
- Added an option to skip the TLS verification