### PR TITLE
Trustchain support for issued certificates

### DIFF
--- a/internal/issuer/horizon/util.go
+++ b/internal/issuer/horizon/util.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	"fmt"
 	"github.com/evertrust/horizon-go"
+	"github.com/evertrust/horizon-go/rfc5280"
 	horizonapi "github.com/evertrust/horizon-issuer/api/v1alpha1"
 	"net/url"
 )
@@ -27,4 +28,25 @@ func ClientFromIssuer(issuerSpec *horizonapi.IssuerSpec, secretData map[string][
 	}
 
 	return client, nil
+}
+
+// BuildPemTrustchain constructs a PEM-encoded leaf-to-root trust chain, given a collection
+// of rfc5280.CfCertificate objects in the leaf-to-root order. If present at the end of the chain,
+// the certification authority will also be returned.
+func BuildPemTrustchain(certs []rfc5280.CfCertificate) (chain string, ca string) {
+	for i, certificate := range certs {
+		if i == len(certs)-1 {
+			if certificate.SelfSigned {
+				// We found a root CA. Add it to the secret ca.crt key.
+				ca = certificate.Pem
+			} else {
+				// Else, we just proceed to append it to our trustchain.
+				chain += certificate.Pem
+			}
+		} else {
+			// Append cert at the end of our trustchain
+			chain += certificate.Pem + "\n"
+		}
+	}
+	return chain, ca
 }


### PR DESCRIPTION
The issuer will now try to construct a trust chain up to the root certification authority and write the trust chain without the CA to the `tls.crt` key, and the CA in the `ca.crt` key. The changes match the expected behavior described at https://cert-manager.io/docs/concepts/certificate/.

Closes #5 