### PR TITLE
Failed requests

### DIFF
--- a/internal/controllers/certificaterequest_controller.go
+++ b/internal/controllers/certificaterequest_controller.go
@@ -191,7 +191,15 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Update the CSR object when returning from the Reconcile function
 	defer func() {
 		if err != nil {
-			setReadyCondition(cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, err.Error())
+			if !cmutil.CertificateRequestHasCondition(&certificateRequest, cmapi.CertificateRequestCondition{
+				Type:   cmapi.CertificateRequestConditionInvalidRequest,
+				Status: cmmeta.ConditionTrue,
+				Reason: cmapi.CertificateRequestReasonFailed,
+			}) {
+				setReadyCondition(cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, err.Error())
+			} else {
+				setReadyCondition(cmmeta.ConditionFalse, cmapi.CertificateRequestReasonFailed, "Invalid request")
+			}
 		}
 
 		var updateErr error


### PR DESCRIPTION
Bad requests to Horizon will now be marked as failed so they are not retried if no parameter is modified. This improves clarity over why a given certificate was not issued.