### PR TITLE
Configure cluster resource namespace

### DIFF
--- a/charts/horizon-issuer/Chart.yaml
+++ b/charts/horizon-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: horizon-issuer
 description: Issue certificates seamlessly using Horizon and cert-manager.
 type: application
-version: 0.0.2
-appVersion: "0.0.4"
+version: 0.0.4
+appVersion: "0.0.7"
 sources:
   - https://github.com/evertrust/horizon-issuer

--- a/charts/horizon-issuer/templates/deployment.yaml
+++ b/charts/horizon-issuer/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - /manager
           args:
             - --leader-elect
+            {{- if .Values.clusterResourceNamespace }}
+            - --cluster-resource-namespace {{ .Values.clusterResourceNamespace }}
+            {{- end }}
             {{- if .Values.verbose }}
             - --verbose
             {{- end }}

--- a/charts/horizon-issuer/values.yaml
+++ b/charts/horizon-issuer/values.yaml
@@ -58,3 +58,5 @@ affinity: {}
 env: {}
 
 verbose: false
+
+clusterResourceNamespace: ""

--- a/charts/horizon-issuer/values.yaml
+++ b/charts/horizon-issuer/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: registry.evertrust.io/horizon-issuer
-  tag: 0.0.4
+  tag: 0.0.7
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Cluster resource namespace is the namespace used to fetch secrets for non-namespaces resources such as `ClusterIssuer`s. You can now configure it through the `clusterResourceNamespace` key in the `values.yaml` file.