### PR TITLE
fix(rbac): give get,list and watch verbs on ingresses

### DIFF
--- a/charts/horizon-issuer/templates/role.yaml
+++ b/charts/horizon-issuer/templates/role.yaml
@@ -46,4 +46,9 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
     verbs: ["approve"]
+
+  # Ingress
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
 {{ end }}


### PR DESCRIPTION
While testing the clusterIssuer on Ingresses, I encountered the following errors :

```
12:48:09.902531       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: failed to list *v1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:horizon-issuer:horizon-issuer" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
E0812 12:48:09.902570       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: Failed to watch *v1.Ingress: failed to list *v1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:horizon-issuer:horizon-issuer" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
```
The issuer stopped calling horizon from this point, all new certificates where leaved in status Ready: False, even those not created by an ingress.

The CertificateRequestReconciler need to get the ingresses associated with a certificate if any. This MR adds the verbs to the rbac role.

I did not find any kubebuilder annotations in the reconciler code to generate the rbac role, so I deduce that kubebuilder wasn't used to generate the role, so I added mandatory verbs directly into the chart.
