### PR TITLE
fix(certificaterequest): avoid stuck approved requests and store Horizon request status in annotation

### DIFF
--- a/internal/controller/certificaterequest_controller.go
+++ b/internal/controller/certificaterequest_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -219,13 +220,16 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 			r.Recorder.Event(&certificateRequest, corev1.EventTypeWarning, "Error", err.Error())
 		}
 
-		var updateErr, parentUpdateErr error
+		metadataChanged := !reflect.DeepEqual(certificateRequestCopy.Annotations, certificateRequest.Annotations) ||
+			!reflect.DeepEqual(certificateRequestCopy.Finalizers, certificateRequest.Finalizers)
+		statusChanged := !reflect.DeepEqual(certificateRequestCopy.Status, certificateRequest.Status)
 
-		// if annotations changed we have to call .Update() and not .UpdateStatus()
-		if !reflect.DeepEqual(certificateRequestCopy.Annotations, certificateRequest.Annotations) {
-			updateErr = r.Update(ctx, &certificateRequest)
-		} else {
-			updateErr = r.Status().Update(ctx, &certificateRequest)
+		var updateErr, statusUpdateErr, parentUpdateErr error
+		if metadataChanged {
+			updateErr = r.updateCertificateRequestMetadataWithRetry(ctx, req.NamespacedName, &certificateRequest)
+		}
+		if statusChanged {
+			statusUpdateErr = r.updateCertificateRequestStatusWithRetry(ctx, req.NamespacedName, &certificateRequest)
 		}
 
 		// if CertificateIdAnnotation was set, we should update the parent Certificate object with the annotation
@@ -242,8 +246,8 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 			parentUpdateErr = r.Update(ctx, certificate)
 		}
 
-		if updateErr != nil {
-			err = utilerrors.NewAggregate([]error{err, updateErr, parentUpdateErr})
+		if updateErr != nil || statusUpdateErr != nil || parentUpdateErr != nil {
+			err = utilerrors.NewAggregate([]error{err, updateErr, statusUpdateErr, parentUpdateErr})
 			result = ctrl.Result{}
 		}
 	}()
@@ -291,35 +295,35 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// If CertificateRequest has not been approved, we should submit the request.
 	if !cmutil.CertificateRequestIsApproved(&certificateRequest) {
-		// If the request has been submitted to Horizon, pull info from Horizon
-		if _, ok := certificateRequest.Annotations[horizonissuer.RequestIdAnnotation]; ok {
-			return r.Issuer.UpdateRequest(ctx, &certificateRequest)
-		} else {
-			certificate, err := issuerutil.CertificateFromRequest(r.Client, ctx, &certificateRequest)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("%w", err)
-			}
-			parentIssuingReason := cmutil.GetCertificateCondition(certificate, cmapi.CertificateConditionIssuing).Reason
-			// If the parent certificate already has a CertificateIdAnnotation, we should submit a renew request
-			shoudlRenew := metav1.HasAnnotation(certificate.ObjectMeta, horizonissuer.LastCertificateIdAnnotation) &&
-				(parentIssuingReason == "ManuallyTriggered" || parentIssuingReason == "Renewing" || parentIssuingReason == "Expired")
-
-			if shoudlRenew {
-				return r.Issuer.SubmitRenewRequest(ctx, *issuerSpec, &certificateRequest, certificate.Annotations[horizonissuer.LastCertificateIdAnnotation])
-			} else {
-				// Else, we consider this a new certificate and submit an enroll request
-				labels, owner, team, contactEmail, err := r.certificateMetadata(ctx, &certificateRequest)
-				if err != nil {
-					setReadyCondition(cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, err.Error())
-				}
-				return r.Issuer.SubmitEnrollRequest(ctx, *issuerSpec, labels, owner, team, contactEmail, &certificateRequest)
-			}
-		}
+		setReadyCondition(cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, "Waiting for approval")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, nil
+	requestID := certificateRequest.Annotations[horizonissuer.RequestIdAnnotation]
+	if requestID != "" {
+		return r.Issuer.UpdateRequest(ctx, &certificateRequest)
+	}
+
+	certificate, err := issuerutil.CertificateFromRequest(r.Client, ctx, &certificateRequest)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("%w", err)
+	}
+	parentIssuingReason := cmutil.GetCertificateCondition(certificate, cmapi.CertificateConditionIssuing).Reason
+	// If the parent certificate already has a CertificateIdAnnotation, we should submit a renew request
+	shouldRenew := metav1.HasAnnotation(certificate.ObjectMeta, horizonissuer.LastCertificateIdAnnotation) &&
+		(parentIssuingReason == "ManuallyTriggered" || parentIssuingReason == "Renewing" || parentIssuingReason == "Expired")
+
+	if shouldRenew {
+		return r.Issuer.SubmitRenewRequest(ctx, *issuerSpec, &certificateRequest, certificate.Annotations[horizonissuer.LastCertificateIdAnnotation])
+	}
+
+	// Else, we consider this a new certificate and submit an enroll request
+	labels, owner, team, contactEmail, err := r.certificateMetadata(ctx, &certificateRequest)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("%w", err)
+	}
+	return r.Issuer.SubmitEnrollRequest(ctx, *issuerSpec, labels, owner, team, contactEmail, &certificateRequest)
 }
 
 func (r *CertificateRequestReconciler) handleDeletion(ctx context.Context, certificateRequest *cmapi.CertificateRequest) error {
@@ -339,10 +343,96 @@ func (r *CertificateRequestReconciler) handleDeletion(ctx context.Context, certi
 		// remove our finalizer from the list and update it.
 		controllerutil.RemoveFinalizer(certificateRequest, FinalizerName)
 		if err := r.Update(ctx, certificateRequest); err != nil {
-			return nil
+			return err
 		}
 	}
 
+	return nil
+}
+
+func (r *CertificateRequestReconciler) updateCertificateRequestMetadataWithRetry(ctx context.Context, name types.NamespacedName, desired *cmapi.CertificateRequest) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest cmapi.CertificateRequest
+		if err := r.Get(ctx, name, &latest); err != nil {
+			return err
+		}
+
+		latest.Annotations = mergeStringMap(latest.Annotations, desired.Annotations)
+		applyManagedFinalizer(&latest, desired)
+
+		return r.Update(ctx, &latest)
+	})
+}
+
+func (r *CertificateRequestReconciler) updateCertificateRequestStatusWithRetry(ctx context.Context, name types.NamespacedName, desired *cmapi.CertificateRequest) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest cmapi.CertificateRequest
+		if err := r.Get(ctx, name, &latest); err != nil {
+			return err
+		}
+
+		copyManagedStatusFields(&latest, desired)
+		return r.Status().Update(ctx, &latest)
+	})
+}
+
+func mergeStringMap(dst, src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func applyManagedFinalizer(latest, desired *cmapi.CertificateRequest) {
+	hasFinalizer := controllerutil.ContainsFinalizer(desired, FinalizerName)
+	if hasFinalizer && !controllerutil.ContainsFinalizer(latest, FinalizerName) {
+		controllerutil.AddFinalizer(latest, FinalizerName)
+	}
+	if !hasFinalizer && controllerutil.ContainsFinalizer(latest, FinalizerName) {
+		controllerutil.RemoveFinalizer(latest, FinalizerName)
+	}
+}
+
+func copyManagedStatusFields(latest, desired *cmapi.CertificateRequest) {
+	for _, conditionType := range []cmapi.CertificateRequestConditionType{
+		cmapi.CertificateRequestConditionReady,
+		cmapi.CertificateRequestConditionInvalidRequest,
+	} {
+		if desiredCondition := findConditionByType(desired.Status.Conditions, conditionType); desiredCondition != nil {
+			cmutil.SetCertificateRequestCondition(
+				latest,
+				desiredCondition.Type,
+				desiredCondition.Status,
+				desiredCondition.Reason,
+				desiredCondition.Message,
+			)
+		}
+	}
+
+	if desired.Status.FailureTime != nil {
+		t := *desired.Status.FailureTime
+		latest.Status.FailureTime = &t
+	}
+	if len(desired.Status.Certificate) > 0 {
+		latest.Status.Certificate = append([]byte(nil), desired.Status.Certificate...)
+	}
+	if len(desired.Status.CA) > 0 {
+		latest.Status.CA = append([]byte(nil), desired.Status.CA...)
+	}
+}
+
+func findConditionByType(conditions []cmapi.CertificateRequestCondition, conditionType cmapi.CertificateRequestConditionType) *cmapi.CertificateRequestCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
 	return nil
 }
 

--- a/internal/controller/certificaterequest_controller_test.go
+++ b/internal/controller/certificaterequest_controller_test.go
@@ -1,0 +1,181 @@
+package controller
+
+import (
+	"time"
+
+	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	horizonapi "github.com/evertrust/horizon-issuer/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CertificateRequestReconciler", func() {
+	It("should process approved requests without request-id through submit path", func() {
+		testScheme := buildTestScheme()
+		issuer := readyIssuer("ns-a", "issuer-a", "issuer-auth")
+		secret := issuerSecret("ns-a", "issuer-auth")
+		certificateRequest := certificateRequestForTests("ns-a", "req-approved", "issuer-a", true)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(&cmapi.CertificateRequest{}, &horizonapi.Issuer{}).
+			WithObjects(issuer, secret, certificateRequest).
+			Build()
+
+		reconciler := newCertificateRequestReconcilerForTests(fakeClient, testScheme, "ns-a")
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "ns-a",
+				Name:      "req-approved",
+			},
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("certificates.cert-manager.io \"missing-cert\" not found"))
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		var updated cmapi.CertificateRequest
+		Expect(fakeClient.Get(ctx, types.NamespacedName{Namespace: "ns-a", Name: "req-approved"}, &updated)).To(Succeed())
+
+		ready := cmutil.GetCertificateRequestCondition(&updated, cmapi.CertificateRequestConditionReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(cmmeta.ConditionFalse))
+		Expect(ready.Reason).To(Equal(cmapi.CertificateRequestReasonPending))
+		Expect(updated.Annotations["horizon.evertrust.io/request-id"]).To(BeEmpty())
+	})
+
+	It("should wait for approval before submit path", func() {
+		testScheme := buildTestScheme()
+		issuer := readyIssuer("ns-b", "issuer-b", "issuer-auth")
+		secret := issuerSecret("ns-b", "issuer-auth")
+		certificateRequest := certificateRequestForTests("ns-b", "req-pending-approval", "issuer-b", false)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(&cmapi.CertificateRequest{}, &horizonapi.Issuer{}).
+			WithObjects(issuer, secret, certificateRequest).
+			Build()
+
+		reconciler := newCertificateRequestReconcilerForTests(fakeClient, testScheme, "ns-b")
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "ns-b",
+				Name:      "req-pending-approval",
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+		var updated cmapi.CertificateRequest
+		Expect(fakeClient.Get(ctx, types.NamespacedName{Namespace: "ns-b", Name: "req-pending-approval"}, &updated)).To(Succeed())
+
+		ready := cmutil.GetCertificateRequestCondition(&updated, cmapi.CertificateRequestConditionReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(cmmeta.ConditionFalse))
+		Expect(ready.Reason).To(Equal(cmapi.CertificateRequestReasonPending))
+		Expect(ready.Message).To(Equal("Waiting for approval"))
+	})
+})
+
+func buildTestScheme() *runtime.Scheme {
+	testScheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+	Expect(horizonapi.AddToScheme(testScheme)).To(Succeed())
+	Expect(cmapi.AddToScheme(testScheme)).To(Succeed())
+	return testScheme
+}
+
+func newCertificateRequestReconcilerForTests(cl client.Client, sch *runtime.Scheme, clusterResourceNamespace string) *CertificateRequestReconciler {
+	return &CertificateRequestReconciler{
+		Client:                   cl,
+		Scheme:                   sch,
+		Recorder:                 record.NewFakeRecorder(10),
+		ClusterResourceNamespace: clusterResourceNamespace,
+		Clock:                    clock.RealClock{},
+	}
+}
+
+func readyIssuer(namespace, name, secretName string) *horizonapi.Issuer {
+	return &horizonapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: horizonapi.IssuerSpec{
+			URL:            "https://horizon.example",
+			Profile:        "default",
+			AuthSecretName: secretName,
+		},
+		Status: horizonapi.IssuerStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(horizonapi.IssuerConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Success",
+					Message:            "Ready for tests",
+					ObservedGeneration: 1,
+				},
+			},
+		},
+	}
+}
+
+func issuerSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"username": []byte("test"),
+			"password": []byte("test"),
+		},
+	}
+}
+
+func certificateRequestForTests(namespace, name, issuerName string, approved bool) *cmapi.CertificateRequest {
+	certificateRequest := &cmapi.CertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"cert-manager.io/certificate-name": "missing-cert",
+			},
+		},
+		Spec: cmapi.CertificateRequestSpec{
+			Request: []byte("dummy-csr"),
+			IssuerRef: cmmeta.ObjectReference{
+				Group: horizonapi.GroupVersion.Group,
+				Kind:  "Issuer",
+				Name:  issuerName,
+			},
+		},
+	}
+
+	if approved {
+		cmutil.SetCertificateRequestCondition(
+			certificateRequest,
+			cmapi.CertificateRequestConditionApproved,
+			cmmeta.ConditionTrue,
+			"cert-manager.io",
+			"approved for tests",
+		)
+	}
+
+	return certificateRequest
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -60,6 +61,8 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	err = horizonevertrustiov1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = cmapi.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
@@ -108,8 +111,26 @@ func getFirstFoundEnvTestBinaryDir() string {
 		return ""
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
+		if !entry.IsDir() {
+			continue
+		}
+		levelOne := filepath.Join(basePath, entry.Name())
+		if _, err := os.Stat(filepath.Join(levelOne, "etcd")); err == nil {
+			return levelOne
+		}
+
+		levelOneEntries, err := os.ReadDir(levelOne)
+		if err != nil {
+			continue
+		}
+		for _, nested := range levelOneEntries {
+			if !nested.IsDir() {
+				continue
+			}
+			levelTwo := filepath.Join(levelOne, nested.Name())
+			if _, err := os.Stat(filepath.Join(levelTwo, "etcd")); err == nil {
+				return levelTwo
+			}
 		}
 	}
 	return ""

--- a/internal/issuer/horizon/issuer.go
+++ b/internal/issuer/horizon/issuer.go
@@ -19,6 +19,7 @@ import (
 const IssuerNamespace = "horizon.evertrust.io"
 const (
 	RequestIdAnnotation         = IssuerNamespace + "/request-id"
+	RequestStatusAnnotation     = IssuerNamespace + "/request-status"
 	CertificateIdAnnotation     = IssuerNamespace + "/certificate-id"
 	LastCertificateIdAnnotation = IssuerNamespace + "/last-certificate-id"
 	OwnerAnnotation             = IssuerNamespace + "/owner"
@@ -95,6 +96,7 @@ func (r *HorizonIssuer) SubmitEnrollRequest(ctx context.Context, issuer v1beta1.
 
 	// Update the request with the Horizon request ID
 	certificateRequest.Annotations[RequestIdAnnotation] = request.WebRAEnrollRequestOnSubmitResponse.Id
+	certificateRequest.Annotations[RequestStatusAnnotation] = string(models.REQUESTSTATUS_PENDING)
 
 	cmutil.SetCertificateRequestCondition(
 		certificateRequest,
@@ -133,6 +135,7 @@ func (r *HorizonIssuer) SubmitRenewRequest(ctx context.Context, issuer v1beta1.I
 
 	// Update the request with the Horizon request ID
 	certificateRequest.Annotations[RequestIdAnnotation] = request.WebRAEnrollRequestOnSubmitResponse.Id
+	certificateRequest.Annotations[RequestStatusAnnotation] = string(models.REQUESTSTATUS_PENDING)
 
 	cmutil.SetCertificateRequestCondition(
 		certificateRequest,
@@ -160,8 +163,10 @@ func (r *HorizonIssuer) UpdateRequest(ctx context.Context, certificateRequest *c
 	case models.REQUESTSTATUS_COMPLETED:
 		return r.handleCompletedRequest(request.WebRAEnrollRequestOnApproveResponse, certificateRequest)
 	case models.REQUESTSTATUS_PENDING, models.REQUESTSTATUS_APPROVED:
+		setRequestStatusAnnotation(certificateRequest, string(request.WebRAEnrollRequestOnApproveResponse.Status))
 		return r.handlePendingRequest()
 	case models.REQUESTSTATUS_DENIED, models.REQUESTSTATUS_CANCELED:
+		setRequestStatusAnnotation(certificateRequest, string(request.WebRAEnrollRequestOnApproveResponse.Status))
 		return r.handleDeniedRequest(certificateRequest)
 	}
 
@@ -204,6 +209,8 @@ func (r *HorizonIssuer) handleFailedRequest(certificateRequest *cmapi.Certificat
 }
 
 func (r *HorizonIssuer) handleDeniedRequest(certificateRequest *cmapi.CertificateRequest) (result ctrl.Result, err error) {
+	setRequestStatusAnnotation(certificateRequest, string(models.REQUESTSTATUS_DENIED))
+
 	cmutil.SetCertificateRequestCondition(
 		certificateRequest,
 		cmapi.CertificateRequestConditionReady,
@@ -230,6 +237,7 @@ func (r *HorizonIssuer) handleCompletedRequest(request *models.WebRAEnrollReques
 			if certificateRequest.Annotations == nil {
 				certificateRequest.Annotations = make(map[string]string)
 			}
+			certificateRequest.Annotations[RequestStatusAnnotation] = string(models.REQUESTSTATUS_COMPLETED)
 			certificateRequest.Annotations[CertificateIdAnnotation] = request.Certificate.Get().GetId()
 			certificateRequest.Annotations[OwnerAnnotation] = request.Certificate.Get().GetOwner()
 			certificateRequest.Annotations[TeamAnnotation] = request.Certificate.Get().GetTeam()
@@ -252,4 +260,11 @@ func (r *HorizonIssuer) handleCompletedRequest(request *models.WebRAEnrollReques
 
 	// We don't requeue this request since it is completed
 	return ctrl.Result{}, nil
+}
+
+func setRequestStatusAnnotation(certificateRequest *cmapi.CertificateRequest, status string) {
+	if certificateRequest.Annotations == nil {
+		certificateRequest.Annotations = make(map[string]string)
+	}
+	certificateRequest.Annotations[RequestStatusAnnotation] = status
 }

--- a/internal/issuer/horizon/issuer.go
+++ b/internal/issuer/horizon/issuer.go
@@ -89,6 +89,10 @@ func (r *HorizonIssuer) SubmitEnrollRequest(ctx context.Context, issuer v1beta1.
 		return r.handleFailedRequest(certificateRequest, err)
 	}
 
+	if certificateRequest.Annotations == nil {
+		certificateRequest.Annotations = make(map[string]string)
+	}
+
 	// Update the request with the Horizon request ID
 	certificateRequest.Annotations[RequestIdAnnotation] = request.WebRAEnrollRequestOnSubmitResponse.Id
 
@@ -121,6 +125,10 @@ func (r *HorizonIssuer) SubmitRenewRequest(ctx context.Context, issuer v1beta1.I
 		Execute()
 	if err != nil {
 		return r.handleFailedRequest(certificateRequest, err)
+	}
+
+	if certificateRequest.Annotations == nil {
+		certificateRequest.Annotations = make(map[string]string)
 	}
 
 	// Update the request with the Horizon request ID
@@ -198,9 +206,9 @@ func (r *HorizonIssuer) handleFailedRequest(certificateRequest *cmapi.Certificat
 func (r *HorizonIssuer) handleDeniedRequest(certificateRequest *cmapi.CertificateRequest) (result ctrl.Result, err error) {
 	cmutil.SetCertificateRequestCondition(
 		certificateRequest,
-		cmapi.CertificateRequestConditionDenied,
-		cmmeta.ConditionTrue,
-		"horizon.evertrust.io",
+		cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse,
+		cmapi.CertificateRequestReasonDenied,
 		"Request denied on Horizon",
 	)
 
@@ -208,14 +216,6 @@ func (r *HorizonIssuer) handleDeniedRequest(certificateRequest *cmapi.Certificat
 }
 
 func (r *HorizonIssuer) handleCompletedRequest(request *models.WebRAEnrollRequestOnApproveResponse, certificateRequest *cmapi.CertificateRequest) (result ctrl.Result, err error) {
-	cmutil.SetCertificateRequestCondition(
-		certificateRequest,
-		cmapi.CertificateRequestConditionApproved,
-		cmmeta.ConditionTrue,
-		"horizon.evertrust.io",
-		"Request approved on Horizon",
-	)
-
 	resp, _, err := r.Client.Rfc5280API.Rfc5280TcPem(context.Background(), request.GetCertificate().Certificate).Order("ltr").Execute()
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("%w: %v", errors.New("unable to build a trust chain for certificate"), err)
@@ -227,6 +227,9 @@ func (r *HorizonIssuer) handleCompletedRequest(request *models.WebRAEnrollReques
 			certificateRequest.Status.CA = []byte(ca)
 		}
 		if certificate != "" {
+			if certificateRequest.Annotations == nil {
+				certificateRequest.Annotations = make(map[string]string)
+			}
 			certificateRequest.Annotations[CertificateIdAnnotation] = request.Certificate.Get().GetId()
 			certificateRequest.Annotations[OwnerAnnotation] = request.Certificate.Get().GetOwner()
 			certificateRequest.Annotations[TeamAnnotation] = request.Certificate.Get().GetTeam()

--- a/internal/issuer/horizon/issuer_test.go
+++ b/internal/issuer/horizon/issuer_test.go
@@ -1,0 +1,34 @@
+package horizon
+
+import (
+	"testing"
+
+	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/evertrust/horizon-go/v2/models"
+)
+
+func TestHandleDeniedRequestStoresHorizonStatusAnnotation(t *testing.T) {
+	issuer := &HorizonIssuer{}
+	certificateRequest := &cmapi.CertificateRequest{}
+
+	if _, err := issuer.handleDeniedRequest(certificateRequest); err != nil {
+		t.Fatalf("handleDeniedRequest returned error: %v", err)
+	}
+
+	if got := certificateRequest.Annotations[RequestStatusAnnotation]; got != string(models.REQUESTSTATUS_DENIED) {
+		t.Fatalf("unexpected %s annotation: got %q", RequestStatusAnnotation, got)
+	}
+
+	ready := cmutil.GetCertificateRequestCondition(certificateRequest, cmapi.CertificateRequestConditionReady)
+	if ready == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if ready.Status != cmmeta.ConditionFalse {
+		t.Fatalf("unexpected Ready status: got %s", ready.Status)
+	}
+	if ready.Reason != cmapi.CertificateRequestReasonDenied {
+		t.Fatalf("unexpected Ready reason: got %s", ready.Reason)
+	}
+}


### PR DESCRIPTION
Fixes #41

This patch makes CertificateRequest reconciliation converge safely when another approver sets `Approved=True` concurrently with horizon-issuer updates.

  Changes:
  - change the reconcile decision flow to:
    - denied -> fail
    - not approved -> wait/requeue
    - approved + no request-id -> submit
    - approved + request-id -> poll/update
  - add retry-on-conflict for metadata and status persistence
  - avoid mutating cert-manager-owned approval conditions
  - store Horizon-specific request state in a controller-managed annotation:
    `horizon.evertrust.io/request-status`

  Tests:
  - added regression coverage for the stuck `Approved=True` / missing `request-id` reconcile path
  - added issuer-side coverage for Horizon request status annotation on denied flow

  Validated:
  - `go test ./...`
  - manual cluster validation with successful re-issuance and `CertificateRequest` transition to `Ready=True`