### PR TITLE
fix(resources): raise default manager memory limit to 512Mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,15 +83,16 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
+        # Memory scales with the number of CertificateRequests the controller
+        # caches cluster-wide; raise the limit on large clusters.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
         volumeMounts: []
       volumes: []
       serviceAccountName: controller-manager

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -50,15 +50,16 @@ manager:
       - ALL
     readOnlyRootFilesystem: true
 
-  ## Resource limits and requests
-  ##
+  ## Resource limits and requests.
+  ## Memory scales with the number of CertificateRequests the controller caches
+  ## cluster-wide; raise the limit on large clusters.
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 512Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 128Mi
 
   ## Manager pod's affinity
   ##


### PR DESCRIPTION
Hello, and thanks for the excellent horizon-issuer — the cert-manager integration has been working really well for us.

I ran into a problem in production and wanted to share the fix. On a cluster issuing for a few dozen workloads, the controller was being OOMKilled and restarting periodically. It wasn't obvious at first — it shows up as silent restarts rather than an error. The cause is that the manager's informer caches all `CertificateRequests` cluster-wide, and the memory footprint exceeds the kubebuilder scaffold default of `128Mi` once there are enough requests.

This PR raises the default limit to `512Mi` (and the request to `128Mi`), in both the Helm chart values and `config/manager/manager.yaml`, and adds a note that memory scales with the number of `CertificateRequests`. We've run `512Mi` and it's stable; `256Mi` is likely fine for small clusters.
